### PR TITLE
Remove typing dependency

### DIFF
--- a/changelog/@unreleased/pr-3.v2.yml
+++ b/changelog/@unreleased/pr-3.v2.yml
@@ -1,0 +1,5 @@
+type: deprecation
+deprecation:
+  description: Removed typing and setuptools_scm as project requirements
+  links:
+  - https://github.com/palantir/palantir-oauth-client/pull/3

--- a/changelog/@unreleased/pr-3.v2.yml
+++ b/changelog/@unreleased/pr-3.v2.yml
@@ -1,5 +1,5 @@
-type: deprecation
-deprecation:
+type: manualTask
+manualTask:
   description: Removed typing and setuptools_scm as project requirements
   links:
   - https://github.com/palantir/palantir-oauth-client/pull/3

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - oauthlib
     - requests
     - requests-oauthlib
-    - typing
 
 test:
   requires:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ python = "^3.8"
 oauthlib = "^3.2.2"
 requests = "^2.28.2"
 requests-oauthlib = "^1.3.1"
-typing = "^3.7.4"
 urllib3 = "^1.26.14"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ black = "^22.1.0"
 [build-system]
 requires = [
     "setuptools >= 35.0.2",
-    "setuptools_scm >= 2.0.0, <3",
     "poetry-core>=1.0.0"
 ]
 build-backend = "poetry.core.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     url="https://github.com/palantir/palantir-oauth-client",
     packages=find_packages(exclude=["test*", "integration*"]),
     python_requires=">=3",
-    install_requires=["oauthlib", "requests", "requests-oauthlib", "typing"],
+    install_requires=["oauthlib", "requests", "requests-oauthlib"],
     extras_require={
         "test": ["pytest", "mockito", "pytest-mockito", "expects", "tox"]
     },


### PR DESCRIPTION
## Before this PR
- `typing` lib was a project required dependency, but it's implicit with python 3.8
- `setuptools_scm` was a project build requirement, but not enabled 

## After this PR
- `typing`  and `setuptools_scm` are no longer required
==COMMIT_MSG==
Removed typing and setuptools_scm as project requirements
==COMMIT_MSG==

## Possible downsides?
None

## Are Docs needed?
No
