### PR TITLE
use datetime methods with timezone instead of the utc methods

### DIFF
--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Switch to datetime methods using timezones.
+  links:
+  - https://github.com/palantir/palantir-oauth-client/pull/8
+

--- a/palantir_oauth_client/_utils.py
+++ b/palantir_oauth_client/_utils.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 import calendar
 import requests_oauthlib
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Any, Mapping, Sequence, Tuple
 from urllib3.util import parse_url
 from urllib.parse import urlparse, parse_qs
@@ -34,7 +34,7 @@ def get_hostname(url: str) -> str:
 
 def utcnow() -> datetime:
     """Returns the current UTC datetime."""
-    return datetime.utcnow()
+    return datetime.now(tz=UTC)
 
 
 def datetime_to_secs(value: datetime) -> int:
@@ -55,10 +55,7 @@ def session_from_client_config(
     return session, client_config
 
 
-def is_state_valid(
-    stored_state,
-    url
-) -> (bool, str):
+def is_state_valid(stored_state, url) -> (bool, str):
     parsed_url = urlparse(url)
     url_query = parse_qs(parsed_url.query)
     received_state = url_query.get("state", None)

--- a/palantir_oauth_client/_utils.py
+++ b/palantir_oauth_client/_utils.py
@@ -13,10 +13,11 @@
 #  limitations under the License.
 import calendar
 import requests_oauthlib
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Sequence, Tuple
 from urllib3.util import parse_url
 from urllib.parse import urlparse, parse_qs
+
 
 CLOCK_SKEW_SECONDS = 10
 CLOCK_SKEW = timedelta(seconds=CLOCK_SKEW_SECONDS)
@@ -34,7 +35,7 @@ def get_hostname(url: str) -> str:
 
 def utcnow() -> datetime:
     """Returns the current UTC datetime."""
-    return datetime.now(tz=UTC)
+    return datetime.now(tz=timezone.utc)
 
 
 def datetime_to_secs(value: datetime) -> int:

--- a/palantir_oauth_client/credentials.py
+++ b/palantir_oauth_client/credentials.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import requests_oauthlib
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Any, List, Mapping, Optional
 
 from ._client import refresh_grant
@@ -92,7 +92,7 @@ class Credentials(object):
             client_secret=client_config.get("client_secret"),
             scopes=session.scope,
         )
-        credentials.expiry = datetime.fromtimestamp(session.token["expires_at"], tz=UTC)
+        credentials.expiry = datetime.fromtimestamp(session.token["expires_at"], tz=timezone.utc)
         return credentials
 
     def __getstate__(self):

--- a/palantir_oauth_client/credentials.py
+++ b/palantir_oauth_client/credentials.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import requests_oauthlib
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any, List, Mapping, Optional
 
 from ._client import refresh_grant
@@ -27,15 +27,15 @@ class Credentials(object):
     """
 
     def __init__(
-            self,
-            token: str,
-            refresh_token: Optional[str] = None,
-            token_uri: Optional[str] = None,
-            client_id: Optional[str] = None,
-            client_secret: Optional[str] = None,
-            scopes: Optional[List[str]] = None,
-            default_scopes: Optional[List[str]] = None,
-            expiry: Optional[datetime] = None,
+        self,
+        token: str,
+        refresh_token: Optional[str] = None,
+        token_uri: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        scopes: Optional[List[str]] = None,
+        default_scopes: Optional[List[str]] = None,
+        expiry: Optional[datetime] = None,
     ):
         """
         Args:
@@ -65,9 +65,9 @@ class Credentials(object):
 
     @classmethod
     def from_session(
-            cls,
-            session: requests_oauthlib.OAuth2Session,
-            client_config: Mapping[str, Any] = None,
+        cls,
+        session: requests_oauthlib.OAuth2Session,
+        client_config: Mapping[str, Any] = None,
     ):
         """
         Creates :class:`palantir_oauth_client.credentials.Credentials` from a :class:`requests_oauthlib.OAuth2Session`.
@@ -92,9 +92,7 @@ class Credentials(object):
             client_secret=client_config.get("client_secret"),
             scopes=session.scope,
         )
-        credentials.expiry = datetime.utcfromtimestamp(
-            session.token["expires_at"]
-        )
+        credentials.expiry = datetime.fromtimestamp(session.token["expires_at"], tz=UTC)
         return credentials
 
     def __getstate__(self):
@@ -149,9 +147,9 @@ class Credentials(object):
 
     def refresh(self):
         if (
-                self._refresh_token is None
-                or self._token_uri is None
-                or self._client_id is None
+            self._refresh_token is None
+            or self._token_uri is None
+            or self._client_id is None
         ):
             raise RefreshError(
                 "The credentials do not contain the necessary fields need to "
@@ -159,9 +157,7 @@ class Credentials(object):
                 "token_uri, client_id."
             )
 
-        scopes = (
-            self._scopes if self._scopes is not None else self._default_scopes
-        )
+        scopes = self._scopes if self._scopes is not None else self._default_scopes
 
         access_token, refresh_token, expiry, grant_response = refresh_grant(
             self._token_uri,
@@ -178,9 +174,7 @@ class Credentials(object):
         if scopes and "scopes" in grant_response:
             requested_scopes = frozenset(scopes)
             granted_scopes = frozenset(grant_response["scopes"].split())
-            scopes_requested_but_not_granted = (
-                    requested_scopes - granted_scopes
-            )
+            scopes_requested_but_not_granted = requested_scopes - granted_scopes
             if scopes_requested_but_not_granted:
                 raise RefreshError(
                     "Not all requested scopes were granted by the authorization server, missing scopes {}.".format(

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 import requests
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from expects import *
 from mockito import ANY, mock, patch
 
@@ -9,7 +9,7 @@ from palantir_oauth_client._client import refresh_grant
 from palantir_oauth_client.errors import RefreshError
 
 
-now = datetime.utcnow()
+now = datetime.now(tz=UTC)
 
 
 class TestClient:
@@ -75,9 +75,7 @@ class TestClient:
         )
 
     def test_retryable_error(self):
-        self.response.content = json.dumps(
-            {"error": "internal_failure"}  # noqa
-        )
+        self.response.content = json.dumps({"error": "internal_failure"})  # noqa
         self.response.status_code = 500  # noqa
 
         def _post(token_uri, body, headers):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 import requests
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta,timezone
 from expects import *
 from mockito import ANY, mock, patch
 
@@ -9,7 +9,7 @@ from palantir_oauth_client._client import refresh_grant
 from palantir_oauth_client.errors import RefreshError
 
 
-now = datetime.now(tz=UTC)
+now = datetime.now(tz=timezone.utc)
 
 
 class TestClient:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The datetime methods [utcnow](https://docs.python.org/3/library/datetime.html?highlight=datetime#datetime.datetime.utcnow) and [utcfromtimestamp](https://docs.python.org/3/library/datetime.html?highlight=datetime#datetime.datetime.utcfromtimestamp)
should not be used as they don't contain timezone information, as mentioned in the linked python documentation.

Python datetime objects without timezone information are essentially just tuples with the year,month,date,hour,minute,second,...
Without a timezone attribute the datetime object is not really useful, as you can't trace back in which timezone this object was created.

This is the same as telling someone in an international team that the meeting will start at 9am.
Instead it is more useful if you tell this person that the meeting starts at 9am UTC.

That is why I think this should get changed in the library.

After the PR you will also be able to compare it to the time from the python time module.
You could do this before, but it didn't return the result you would expect. Except your system uses the UTC timezone.

```python
from datetime import datetime,UTC
import time
# For example if the system uses Europe/Berlin (DST) as timezone this will return 7200 seconds
# time.time returns the correct unix time, while datetime.utcnow().timestamp() returns the 'wrong' unixtime
time.time() - datetime.utcnow().timestamp()
# but this will return 0 seconds
time.time() - datetime.now(tz=UTC).timestamp()
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
the utcnow method uses `datetime.now(tz=UTC)` instead of `datetime.utcnow()` which is the recommended way.
the `credentials.expiry` attribute now also has UTC timezone information

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
the `credentials.expiry` is now "offset-aware". This means you can't compare it to offset-native (without timezone info) datetime objects.
```python
from datetime import datetime,UTC

# will raise a TypeError
# datetime.now() -> 2023,1,1,12,0,0
# datetime.now(tz=UTC) -> 2023,1,1,10,0,0,tz=UTC
datetime.now() > datetime.now(tz=UTC)

# this would work, but doesn't make any sense
# datetime.now() returns the numbers in your local time
# datetime.utcnow() returns the numbers in UTC time
# but none of these objects will 'know' that they are the same time
# e.g datetime.now() -> 2023,1,1,12,0,0
# e.g. datetime.utcnow() -> 2023,1,1,10,0,0
# would return true
datetime.now() > datetime.utcnow()
```

## Are Docs needed?
<!-- Please indicate whether documentation is needed for this PR. -->

Maybe, signaling to people that the expiration attribute is now timezone-offset "aware"?
This is how python calls it in the error message when comparing
offset-native (datetime.now(), without timezone information)
and offset-aware (datetime.now(tz=UTC), with timezone information) datetime objects